### PR TITLE
Fix für den Überlauf im Dashboard-Widget

### DIFF
--- a/functions/admin-dashboard.php
+++ b/functions/admin-dashboard.php
@@ -51,7 +51,7 @@ function kr8_rss_dashboard_widget() {
 		</a>
 	</h4>
 	<p style="margin-top: 0.5em;">
-		<?php echo substr($item->get_description(), 0, 200); ?>
+		<?php echo substr($item->get_description(), 24); ?>
 	</p>
 	<?php }
 }


### PR DESCRIPTION
Durch das Abtrennen der ersten 24 Zeichen von 'get_description' wird das '<pre>'-Tag entfernt und der Text mit Umbruch dargestellt.
Außerdem denke ich, dass die Commit-Beschreibungen ruhig vollständig, bzw. als vollständige (die Kurzfassung bevorzugende) description angezeigt werden kann.
Das ist in Ergänzung zu #8